### PR TITLE
Allow map table to be passed in directly

### DIFF
--- a/sti/init.lua
+++ b/sti/init.lua
@@ -23,21 +23,26 @@ local Map        = {}
 Map.__index      = Map
 
 local function new(map, plugins, ox, oy)
-	-- Check for valid map type
-	local ext = map:sub(-4, -1)
-	assert(ext == ".lua", string.format(
-		"Invalid file type: %s. File must be of type: lua.",
-		ext
-	))
+	if type(map) == "table" then
+		map = setmetatable(map, Map)
+	else
+		-- Check for valid map type
+		local ext = map:sub(-4, -1)
+		assert(ext == ".lua", string.format(
+			"Invalid file type: %s. File must be of type: lua.",
+			ext
+		))
 
-	-- Get path to map
-	local path = map:reverse():find("[/\\]") or ""
-	if path ~= "" then
-		path = map:sub(1, 1 + (#map - path))
+		-- Get path to map
+		local path = map:reverse():find("[/\\]") or ""
+		if path ~= "" then
+			path = map:sub(1, 1 + (#map - path))
+		end
+
+		-- Load map
+		map = setmetatable(love.filesystem.load(map)(), Map)
 	end
-
-	-- Load map
-	map = setmetatable(love.filesystem.load(map)(), Map)
+	
 	map:init(path, plugins, ox, oy)
 
 	return map


### PR DESCRIPTION
@karai17: this pull request is inspired by the first few posts on [a thread in the LOVE forums](https://love2d.org/forums/viewtopic.php?f=14&t=82843), specifically the need to randomly generate maps for a roguelike and to be able to pass those randomly-generated maps to STI as a table instead of a path.

I think the OP moved on and didn't end up using STI (I didn't see STI in a casual skim of [the repo](https://github.com/Zireael07/veins-of-the-earth-love)), but regardless, I would love it if STI supported this ability since it would allow more people to use STI, which benefits libraries that depend on or interoperate with STI.

I would like to test this a bit before it gets merged and if you'd like I can update the documentation in this pull request and any other chores you would like. But I wanted to open the pull request early, before investing more time, to check if you would be open to this kind of change. I would like to write some helper functions that assist in generating the table to be passed in, but I'm not sure if those would belong in STI itself, or in a separate repo. Do you have any preferences?